### PR TITLE
Move whitenoise config to development settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ coverage.xml
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+staticfiles/
 
 # Flask stuff:
 instance/

--- a/quickstartproject/production.py
+++ b/quickstartproject/production.py
@@ -5,20 +5,4 @@ import os
 # that Azure automatically creates for us.
 ALLOWED_HOSTS = [os.environ['WEBSITE_HOSTNAME']] if 'WEBSITE_HOSTNAME' in os.environ else []
 
-# WhiteNoise configuration
-MIDDLEWARE = [                                                                   
-    'django.middleware.security.SecurityMiddleware',
-# Add whitenoise middleware after the security middleware                             
-    'whitenoise.middleware.WhiteNoiseMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',                      
-    'django.middleware.common.CommonMiddleware',                                 
-    'django.middleware.csrf.CsrfViewMiddleware',                                 
-    'django.contrib.auth.middleware.AuthenticationMiddleware',                   
-    'django.contrib.messages.middleware.MessageMiddleware',                      
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',                    
-]
-
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'  
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-
 DEBUG = False

--- a/quickstartproject/settings.py
+++ b/quickstartproject/settings.py
@@ -42,14 +42,16 @@ INSTALLED_APPS = [
     'hello_azure'
 ]
 
-MIDDLEWARE = [
+MIDDLEWARE = [                                                                   
     'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+# Add whitenoise middleware after the security middleware                             
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',                      
+    'django.middleware.common.CommonMiddleware',                                 
+    'django.middleware.csrf.CsrfViewMiddleware',                                 
+    'django.contrib.auth.middleware.AuthenticationMiddleware',                   
+    'django.contrib.messages.middleware.MessageMiddleware',                      
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',                    
 ]
 
 ROOT_URLCONF = 'quickstartproject.urls'
@@ -120,6 +122,9 @@ USE_TZ = True
 
 STATICFILES_DIRS = (str(BASE_DIR.joinpath('static')),)
 STATIC_URL = 'static/'
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'  
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field

--- a/quickstartproject/settings.py
+++ b/quickstartproject/settings.py
@@ -44,7 +44,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [                                                                   
     'django.middleware.security.SecurityMiddleware',
-# Add whitenoise middleware after the security middleware                             
+    # Add whitenoise middleware after the security middleware             
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',                      
     'django.middleware.common.CommonMiddleware',                                 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Currently, settings.py contains `whitenoise.runserver_nostatic` in `INSTALLED_APPS`. This setting disables the django runserver from serving static files, but there is no middleware setting for whitenoise that would enable it to take over serving static files, which means that static files don't get served when running in development (locally). This PR moves whitenoise middleware configuration, and `STATICFILES_STORAGE`/`STATIC_ROOT` settings from production.py to settings.py so that whitenoise can serve static files in development. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/JimacoMS4/msdocs-python-django-webapp-quickstart.git
cd msdocs-python-django-webapp-quickstart
git checkout add-whitenoise-to-dev

```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->

Follow the (Django) instructions in [Quickstart: Deploy a Python (Django or Flask) web app to Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/quickstart-python?tabs=django%2Cwindows%2Cazure-cli%2Cvscode-deploy%2Cdeploy-instructions-azportal%2Cterminal-bash%2Cdeploy-instructions-zip-azcli) to deploy the webapp locally and on Azure using the clone and branch above. 


## What to Check
Verify that the following are valid
* Observe that the website runs in local and production environment and that static files are served. i.e. page looks like image in article.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
**Note** There's no need to run `python manage.py collectstatic` when running locally because the [WHITENOISE_USE_FINDERS](https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_USE_FINDERS) setting is set to the same value as DEBUG (True). In production, App Services runs the command as part of its build process. 